### PR TITLE
[R/S] bdroid_buildcfg: Use space between the device number and revision

### DIFF
--- a/bluetooth/bdroid_buildcfg.h
+++ b/bluetooth/bdroid_buildcfg.h
@@ -33,7 +33,7 @@ static inline const char* getBTDefaultName()
     property_get("ro.boot.hardware", device, "");
 
     if (!strcmp("pdx213", device)) {
-        return "Xperia 10III";
+        return "Xperia 10 III";
     }
 
     return "Xperia";


### PR DESCRIPTION
Just like the other platforms and stock, and simply because it looks
much better that way, add a space between `10III`.

Signed-off-by: Marijn Suijten <marijn.suijten@somainline.org>
