### PR TITLE
Add LMK tuning that was missing compared to previous devices

### DIFF
--- a/rootdir/vendor/etc/init/init.lena.rc
+++ b/rootdir/vendor/etc/init/init.lena.rc
@@ -69,3 +69,9 @@ on property:sys.boot_completed=1
     write /sys/block/sdc/queue/iostats 1
     write /sys/block/dm-0/queue/read_ahead_kb 512
     write /sys/block/dm-1/queue/read_ahead_kb 512
+
+    # LMK tuning
+    write /sys/module/lowmemorykiller/parameters/enable_lmk 1
+    write /sys/module/lowmemorykiller/parameters/minfree "15360,19200,23040,26880,34415,43737"
+    write /sys/module/lowmemorykiller/parameters/vmpressure_file_min 105984
+    write /sys/module/lowmemorykiller/parameters/oom_reaper 1


### PR DESCRIPTION
Copied from https://github.com/sonyxperiadev/device-sony-seine/blob/master/rootdir/vendor/etc/init/init.seine.rc
Fixes #16 
SailfishOS suffers from this not being present. I would love to know why this is no longer present and in turn why are the new `minfree` values so big.