### PR TITLE
Fix policies leading to Gold cores values being unset

### DIFF
--- a/rootdir/vendor/etc/init/init.lena.pwr.rc
+++ b/rootdir/vendor/etc/init/init.lena.pwr.rc
@@ -73,12 +73,12 @@ on property:sys.boot_completed=1
     write /sys/devices/system/cpu/cpufreq/policy0/schedutil/pl 1
 
     # configure governor settings for gold cluster
-    write /sys/devices/system/cpu/cpufreq/policy4/scaling_governor "schedutil"
-    write /sys/devices/system/cpu/cpufreq/policy4/schedutil/up_rate_limit_us 0
-    write /sys/devices/system/cpu/cpufreq/policy4/schedutil/down_rate_limit_us 0
-    write /sys/devices/system/cpu/cpufreq/policy4/schedutil/hispeed_freq 1248000
-    write /sys/devices/system/cpu/cpufreq/policy4/scaling_min_freq 652800
-    write /sys/devices/system/cpu/cpufreq/policy4/schedutil/pl 1
+    write /sys/devices/system/cpu/cpufreq/policy6/scaling_governor "schedutil"
+    write /sys/devices/system/cpu/cpufreq/policy6/schedutil/up_rate_limit_us 0
+    write /sys/devices/system/cpu/cpufreq/policy6/schedutil/down_rate_limit_us 0
+    write /sys/devices/system/cpu/cpufreq/policy6/schedutil/hispeed_freq 1248000
+    write /sys/devices/system/cpu/cpufreq/policy6/scaling_min_freq 787200
+    write /sys/devices/system/cpu/cpufreq/policy6/schedutil/pl 1
 
     write /sys/module/cpu_boost/parameters/input_boost_freq "0:1324800"
     write /sys/module/cpu_boost/parameters/input_boost_ms 120


### PR DESCRIPTION
Fixes #20 
Changed `policy4` to `policy6` as well as `min_freq` to `787200`