### PR TITLE
init: Adjust LMK tuning values for Lena

### DIFF
--- a/rootdir/vendor/etc/init/init.lena.rc
+++ b/rootdir/vendor/etc/init/init.lena.rc
@@ -72,6 +72,7 @@ on property:sys.boot_completed=1
 
     # LMK tuning
     write /sys/module/lowmemorykiller/parameters/enable_lmk 1
-    write /sys/module/lowmemorykiller/parameters/minfree "15360,19200,23040,26880,34415,43737"
+    write /sys/module/lowmemorykiller/parameters/minfree "167160,190200,213240,236280,356490"
+    write /sys/module/lowmemorykiller/parameters/adj "0,58,147,529,1000"
     write /sys/module/lowmemorykiller/parameters/vmpressure_file_min 105984
     write /sys/module/lowmemorykiller/parameters/oom_reaper 1


### PR DESCRIPTION
When we ported the LMK to Android 11/4.19.x devices, we copied and adjusted the LMK
tunings from Seine for Lena.

Since last PR copied & pasted the invalids configs, here are the
adjust configs to match the values of RAM that the Xperia 10 III/Lena
has.
